### PR TITLE
feat(notifications): update notification preferences and types

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -55,6 +55,7 @@ MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS="noreply@petcare.local"
 MAIL_FROM_NAME="${APP_NAME}"
+POSTMARK_TOKEN=
 
 SES_FROM_ADDRESS=no-reply@petcare.local
 SES_FROM_NAME="PetCare Companion"

--- a/src/README.md
+++ b/src/README.md
@@ -62,9 +62,13 @@ docker-compose exec app tail -n 20 -f storage/logs/laravel.log
 
 Mail Configuration Details
 
-- Driver: Log (writes to `storage/logs/laravel.log`)
+- Driver: Log (writes to `storage/logs/laravel.log`) by default
+- Override `MAIL_MAILER` per environment (`smtp` for Mailhog, `ses` for staging, `postmark` in
+  production)
 - From Address: `noreply@petcare.local`
-- No external mail server required for development
+- Set `POSTMARK_TOKEN` in `.env` when using the Postmark transport
+- Local debug endpoint `/postmark-test` (enabled when `APP_DEBUG=true` or `APP_ENV=local`) triggers
+  a one-off test email using the currently active mailer
 
 ## 💳 Payment & Gift Economy
 

--- a/src/app/Helpers/NotificationHelper.php
+++ b/src/app/Helpers/NotificationHelper.php
@@ -23,7 +23,7 @@ class NotificationHelper
         $key = self::normalizeNotificationKey($notificationType);
 
         // Get preferences if they exist, otherwise default to true
-        $preferences = $user->notificationPreference;
+        $preferences = $user->notificationPreferences;
 
         if (! $preferences) {
             $defaults = config('notifications.defaults.notifications', []);
@@ -46,7 +46,7 @@ class NotificationHelper
         }
 
         // Get preferences if they exist, otherwise default to true
-        $preferences = $user->notificationPreference;
+        $preferences = $user->notificationPreferences;
 
         if (! $preferences) {
             $channelDefaults = config('notifications.defaults.channels', []);
@@ -63,14 +63,13 @@ class NotificationHelper
     private static function normalizeNotificationKey(string $notificationType): string
     {
         return match ($notificationType) {
-            'otp_notifications' => 'otp',
-            'login_notifications' => 'login',
-            'gift_notifications' => 'gift',
-            'gift_send_notifications' => 'gift_send',
-            'pet_update_notifications' => 'pet_update',
-            'pet_create_notifications' => 'pet_create',
-            'pet_delete_notifications' => 'pet_delete',
-            'otp', 'login', 'gift', 'gift_send', 'pet_update', 'pet_create', 'pet_delete' => $notificationType,
+            'otp_notifications', 'otp' => 'otp',
+            'login_notifications', 'login' => 'login',
+            'gift_notifications', 'gift_send_notifications', 'gift', 'gift_send', 'gift_received' => 'gift_received',
+            'pet_create_notifications', 'pet_update_notifications', 'pet_delete_notifications', 'pet_activity', 'pet_create', 'pet_update', 'pet_delete' => 'pet_activity',
+            'appointment_created', 'appointment' => 'appointment_created',
+            'caregiver_invitation' => 'caregiver_invitation',
+            'routine_reminder', 'routine' => 'routine_reminder',
             default => $notificationType,
         };
     }

--- a/src/app/Http/Requests/Auth/User/UpdateNotificationPreferenceRequest.php
+++ b/src/app/Http/Requests/Auth/User/UpdateNotificationPreferenceRequest.php
@@ -28,7 +28,7 @@ class UpdateNotificationPreferenceRequest extends FormRequest
             'type' => [
                 'required',
                 'string',
-                'in:otp,login,gift,pet_update,pet_create,pet_delete,sms,email',
+                'in:pet_activity,appointment_created,caregiver_invitation,gift_received,routine_reminder,sms,email',
             ],
             'enabled' => [
                 'required',
@@ -44,7 +44,7 @@ class UpdateNotificationPreferenceRequest extends FormRequest
     {
         return [
             'type' => [
-                'description' => 'Notification type (e.g., otp, login, gift, pet_update, sms, email)',
+                'description' => 'Notification type (e.g., pet_activity, appointment_created, sms, email)',
                 'example' => 'email',
             ],
             'enabled' => [

--- a/src/app/Jobs/DeleteUserDataJob.php
+++ b/src/app/Jobs/DeleteUserDataJob.php
@@ -67,7 +67,7 @@ class DeleteUserDataJob implements ShouldQueue
             }
 
             // Hard delete user notification preferences
-            $this->user->notificationPreference()?->forceDelete();
+            $this->user->notificationPreferences?->forceDelete();
 
             // Anonymize sensitive data before final deletion
             $this->anonymizeUser();

--- a/src/app/Models/NotificationPreference.php
+++ b/src/app/Models/NotificationPreference.php
@@ -27,6 +27,11 @@ class NotificationPreference extends Model
         'pet_update_notifications',
         'pet_create_notifications',
         'pet_delete_notifications',
+        'pet_activity',
+        'appointment_created',
+        'caregiver_invitation',
+        'gift_received',
+        'routine_reminder',
         'sms_enabled',
         'email_enabled',
     ];
@@ -43,6 +48,11 @@ class NotificationPreference extends Model
         'pet_update_notifications' => 'boolean',
         'pet_create_notifications' => 'boolean',
         'pet_delete_notifications' => 'boolean',
+        'pet_activity' => 'boolean',
+        'appointment_created' => 'boolean',
+        'caregiver_invitation' => 'boolean',
+        'gift_received' => 'boolean',
+        'routine_reminder' => 'boolean',
         'sms_enabled' => 'boolean',
         'email_enabled' => 'boolean',
     ];
@@ -60,6 +70,11 @@ class NotificationPreference extends Model
                 'pet_update_notifications',
                 'pet_create_notifications',
                 'pet_delete_notifications',
+                'pet_activity',
+                'appointment_created',
+                'caregiver_invitation',
+                'gift_received',
+                'routine_reminder',
                 'sms_enabled',
                 'email_enabled',
             ]);
@@ -78,9 +93,15 @@ class NotificationPreference extends Model
      */
     public function isNotificationEnabled(string $type): bool
     {
-        $attribute = "{$type}_notifications";
+        $column = $this->mapNotificationColumn($type);
 
-        return $this->getAttribute($attribute) ?? true;
+        if (! $column) {
+            $defaults = config('notifications.defaults.notifications', []);
+
+            return (bool) ($defaults[$type] ?? true);
+        }
+
+        return (bool) $this->getAttribute($column);
     }
 
     /**
@@ -105,6 +126,11 @@ class NotificationPreference extends Model
             'pet_update_notifications' => false,
             'pet_create_notifications' => false,
             'pet_delete_notifications' => false,
+            'pet_activity' => false,
+            'appointment_created' => false,
+            'caregiver_invitation' => false,
+            'gift_received' => false,
+            'routine_reminder' => false,
         ]);
     }
 
@@ -120,6 +146,29 @@ class NotificationPreference extends Model
             'pet_update_notifications' => true,
             'pet_create_notifications' => true,
             'pet_delete_notifications' => true,
+            'pet_activity' => true,
+            'appointment_created' => true,
+            'caregiver_invitation' => true,
+            'gift_received' => true,
+            'routine_reminder' => true,
         ]);
+    }
+
+    private function mapNotificationColumn(string $type): ?string
+    {
+        return match ($type) {
+            'otp', 'otp_notifications' => 'otp_notifications',
+            'login', 'login_notifications' => 'login_notifications',
+            'gift', 'gift_notifications', 'gift_send', 'gift_send_notifications' => 'gift_notifications',
+            'pet_update', 'pet_update_notifications' => 'pet_update_notifications',
+            'pet_create', 'pet_create_notifications' => 'pet_create_notifications',
+            'pet_delete', 'pet_delete_notifications' => 'pet_delete_notifications',
+            'pet_activity' => 'pet_activity',
+            'appointment_created', 'appointment' => 'appointment_created',
+            'caregiver_invitation' => 'caregiver_invitation',
+            'gift_received' => 'gift_received',
+            'routine_reminder', 'routine' => 'routine_reminder',
+            default => null,
+        };
     }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -23,6 +23,30 @@ class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, HasUuids, LogsActivity, Notifiable;
 
+    protected static function booted(): void
+    {
+        static::created(function (self $user) {
+            $notificationDefaults = config('notifications.defaults.notifications', []);
+            $channelDefaults = config('notifications.defaults.channels', []);
+
+            $user->notificationPreferences()->create([
+                'otp_notifications' => $notificationDefaults['otp'] ?? true,
+                'login_notifications' => $notificationDefaults['login'] ?? true,
+                'gift_notifications' => $notificationDefaults['gift'] ?? true,
+                'pet_update_notifications' => $notificationDefaults['pet_update'] ?? true,
+                'pet_create_notifications' => $notificationDefaults['pet_create'] ?? true,
+                'pet_delete_notifications' => $notificationDefaults['pet_delete'] ?? true,
+                'pet_activity' => $notificationDefaults['pet_activity'] ?? false,
+                'appointment_created' => $notificationDefaults['appointment_created'] ?? false,
+                'caregiver_invitation' => $notificationDefaults['caregiver_invitation'] ?? false,
+                'gift_received' => $notificationDefaults['gift_received'] ?? false,
+                'routine_reminder' => $notificationDefaults['routine_reminder'] ?? false,
+                'sms_enabled' => $channelDefaults['sms'] ?? true,
+                'email_enabled' => $channelDefaults['email'] ?? true,
+            ]);
+        });
+    }
+
     /**
      * The attributes that are mass assignable.
      *
@@ -88,6 +112,11 @@ class User extends Authenticatable
      * Get the user's notification preferences.
      */
     public function notificationPreference()
+    {
+        return $this->notificationPreferences();
+    }
+
+    public function notificationPreferences()
     {
         return $this->hasOne(NotificationPreference::class);
     }

--- a/src/app/Services/Auth/Notifications/NotificationPreferencesService.php
+++ b/src/app/Services/Auth/Notifications/NotificationPreferencesService.php
@@ -24,20 +24,24 @@ class NotificationPreferencesService
         }
 
         // Retrieve existing preferences or create default ones
-        $preferences = $user->notificationPreference;
+        $preferences = $user->notificationPreferences;
 
         if (! $preferences) {
             $notificationDefaults = config('notifications.defaults.notifications', []);
             $channelDefaults = config('notifications.defaults.channels', []);
 
-            $preferences = NotificationPreference::create([
-                'user_id' => $user->id,
+            $preferences = $user->notificationPreferences()->create([
                 'otp_notifications' => $notificationDefaults['otp'] ?? true,
                 'login_notifications' => $notificationDefaults['login'] ?? true,
                 'gift_notifications' => $notificationDefaults['gift'] ?? true,
                 'pet_update_notifications' => $notificationDefaults['pet_update'] ?? true,
                 'pet_create_notifications' => $notificationDefaults['pet_create'] ?? true,
                 'pet_delete_notifications' => $notificationDefaults['pet_delete'] ?? true,
+                'pet_activity' => $notificationDefaults['pet_activity'] ?? false,
+                'appointment_created' => $notificationDefaults['appointment_created'] ?? false,
+                'caregiver_invitation' => $notificationDefaults['caregiver_invitation'] ?? false,
+                'gift_received' => $notificationDefaults['gift_received'] ?? false,
+                'routine_reminder' => $notificationDefaults['routine_reminder'] ?? false,
                 'sms_enabled' => $channelDefaults['sms'] ?? true,
                 'email_enabled' => $channelDefaults['email'] ?? true,
             ]);
@@ -60,12 +64,11 @@ class NotificationPreferencesService
 
         // Map user-friendly type names to database column names
         $typeMapping = [
-            'otp' => 'otp_notifications',
-            'login' => 'login_notifications',
-            'gift' => 'gift_notifications',
-            'pet_update' => 'pet_update_notifications',
-            'pet_create' => 'pet_create_notifications',
-            'pet_delete' => 'pet_delete_notifications',
+            'pet_activity' => 'pet_activity',
+            'appointment_created' => 'appointment_created',
+            'caregiver_invitation' => 'caregiver_invitation',
+            'gift_received' => 'gift_received',
+            'routine_reminder' => 'routine_reminder',
             'sms' => 'sms_enabled',
             'email' => 'email_enabled',
         ];
@@ -73,12 +76,11 @@ class NotificationPreferencesService
         $columnName = $typeMapping[$type] ?? null;
 
         if (! $columnName || ! in_array($columnName, [
-            'otp_notifications',
-            'login_notifications',
-            'gift_notifications',
-            'pet_update_notifications',
-            'pet_create_notifications',
-            'pet_delete_notifications',
+            'pet_activity',
+            'appointment_created',
+            'caregiver_invitation',
+            'gift_received',
+            'routine_reminder',
             'sms_enabled',
             'email_enabled',
         ])) {

--- a/src/app/Services/Pet/PetCaregiverService.php
+++ b/src/app/Services/Pet/PetCaregiverService.php
@@ -29,14 +29,23 @@ class PetCaregiverService
 
         $acceptUrl = config('services.frontend_url', env('FRONTEND_URL')).'/caregiver-invitations/accept?token='.$invitation->token;
 
-        Mail::to($invitation->invitee_email)->queue(
-            new PetCaregiverInvitationMail(
-                $invitation,
-                $pet,
-                $inviter,
-                $acceptUrl
-            )
-        );
+        $shouldSendMail = true;
+        $inviteeUser = User::where('email', $inviteeEmail)->first();
+
+        if ($inviteeUser && $inviteeUser->notificationPreferences && ! $inviteeUser->notificationPreferences->caregiver_invitation) {
+            $shouldSendMail = false;
+        }
+
+        if ($shouldSendMail) {
+            Mail::to($invitation->invitee_email)->queue(
+                new PetCaregiverInvitationMail(
+                    $invitation,
+                    $pet,
+                    $inviter,
+                    $acceptUrl
+                )
+            );
+        }
 
         activity()
             ->performedOn($invitation)

--- a/src/app/Services/Pet/PetGiftService.php
+++ b/src/app/Services/Pet/PetGiftService.php
@@ -73,7 +73,7 @@ class PetGiftService
             $gift->markAsPaid();
 
             // Send notification after gift is successfully paid
-            if (\App\Helpers\NotificationHelper::isNotificationEnabled($user, 'gift_send')) {
+            if (\App\Helpers\NotificationHelper::isNotificationEnabled($user, 'gift_received')) {
                 \Illuminate\Support\Facades\Notification::send($user, new \App\Notifications\Gift\GiftSuccessNotification($gift));
             }
 

--- a/src/app/Services/Pet/PetService.php
+++ b/src/app/Services/Pet/PetService.php
@@ -32,7 +32,7 @@ class PetService
         $pet = Pet::create($data);
 
         // Send pet created notification to owner if preference is enabled
-        if ($pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_create')) {
+        if ($pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_activity')) {
             Notification::send($pet->user, new PetCreatedNotification($pet));
         }
 
@@ -51,7 +51,7 @@ class PetService
         $pet->save();
 
         // Send pet updated notification to owner if there are changes and preference is enabled
-        if (! empty($changes) && $pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_update')) {
+        if (! empty($changes) && $pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_activity')) {
             Notification::send($pet->user, new PetUpdatedNotification($pet, $changes));
         }
 
@@ -64,7 +64,7 @@ class PetService
     public function delete(Pet $pet): void
     {
         // Send pet deleted notification to owner if preference is enabled
-        if ($pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_delete')) {
+        if ($pet->user && NotificationHelper::isNotificationEnabled($pet->user, 'pet_activity')) {
             Notification::send($pet->user, new PetDeletedNotification($pet));
         }
 

--- a/src/app/Services/Webhook/Stripe/StripeWebhookService.php
+++ b/src/app/Services/Webhook/Stripe/StripeWebhookService.php
@@ -167,7 +167,7 @@ class StripeWebhookService
         // are handled at creation time via PetGiftService and do the deduction there.
 
         // Send gift success notification to user if enabled
-        if (NotificationHelper::isNotificationEnabled($gift->user, 'gift')) {
+        if (NotificationHelper::isNotificationEnabled($gift->user, 'gift_received')) {
             Notification::send($gift->user, new GiftSuccessNotification($gift));
         }
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -12,6 +12,7 @@
     "php": "^8.2",
     "aws/aws-sdk-php": "^3.366",
     "barryvdh/laravel-dompdf": "^3.1",
+    "coconutcraig/laravel-postmark": "^3.3",
     "knuckleswtf/scribe": "^5.5",
     "laravel/framework": "^12.0",
     "laravel/horizon": "^5.23",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2aaddd5d979c58519bd49de15455d93",
+    "content-hash": "4449be666f3a7281b73f5315167b7732",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -362,6 +362,86 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "coconutcraig/laravel-postmark",
+            "version": "v3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/craigpaul/laravel-postmark.git",
+                "reference": "099277ed9c9fff89ded4358ce639f46604540642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/craigpaul/laravel-postmark/zipball/099277ed9c9fff89ded4358ce639f46604540642",
+                "reference": "099277ed9c9fff89ded4358ce639f46604540642",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.0",
+                "illuminate/mail": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "fakerphp/faker": "^1.17",
+                "orchestra/testbench": "^8.0|^9.0|^10.0",
+                "phpunit/phpunit": "^10.0|^11.5.3"
+            },
+            "suggest": {
+                "mvdnbrk/postmark-inbound": "Allows you to process Postmark Inbound Webhooks."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "CraigPaul\\Mail\\PostmarkServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CraigPaul\\Mail\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Craig Paul",
+                    "email": "craig.paul@coconutsoftware.com",
+                    "homepage": "https://www.coconutsoftware.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel package for sending mail via the Postmark API",
+            "homepage": "https://github.com/craigpaul/laravel-postmark",
+            "keywords": [
+                "coconutcraig",
+                "email",
+                "laravel",
+                "mail",
+                "postmark",
+                "wildbit"
+            ],
+            "support": {
+                "issues": "https://github.com/craigpaul/laravel-postmark/issues",
+                "source": "https://github.com/craigpaul/laravel-postmark/tree/v3.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mvdnbrk",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-02T22:14:27+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/src/config/mail.php
+++ b/src/config/mail.php
@@ -55,10 +55,6 @@ return [
 
         'postmark' => [
             'transport' => 'postmark',
-            // 'message_stream_id' => env('POSTMARK_MESSAGE_STREAM_ID'),
-            // 'client' => [
-            //     'timeout' => 5,
-            // ],
         ],
 
         'resend' => [

--- a/src/config/notifications.php
+++ b/src/config/notifications.php
@@ -21,6 +21,11 @@ return [
             'pet_update' => true,
             'pet_create' => true,
             'pet_delete' => true,
+            'pet_activity' => false,
+            'appointment_created' => false,
+            'caregiver_invitation' => false,
+            'gift_received' => false,
+            'routine_reminder' => false,
         ],
         'channels' => [
             'sms' => false,

--- a/src/config/services.php
+++ b/src/config/services.php
@@ -15,7 +15,7 @@ return [
     */
 
     'postmark' => [
-        'key' => env('POSTMARK_API_KEY'),
+        'token' => env('POSTMARK_TOKEN'),
     ],
 
     'resend' => [

--- a/src/database/migrations/2025_12_01_000001_add_optional_notification_preferences_columns.php
+++ b/src/database/migrations/2025_12_01_000001_add_optional_notification_preferences_columns.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('notification_preferences')) {
+            return;
+        }
+
+        Schema::table('notification_preferences', function (Blueprint $table) {
+            if (! Schema::hasColumn('notification_preferences', 'pet_activity')) {
+                $table->boolean('pet_activity')->default(false)->after('user_id');
+            }
+
+            if (! Schema::hasColumn('notification_preferences', 'appointment_created')) {
+                $table->boolean('appointment_created')->default(false)->after('pet_activity');
+            }
+
+            if (! Schema::hasColumn('notification_preferences', 'caregiver_invitation')) {
+                $table->boolean('caregiver_invitation')->default(false)->after('appointment_created');
+            }
+
+            if (! Schema::hasColumn('notification_preferences', 'gift_received')) {
+                $table->boolean('gift_received')->default(false)->after('caregiver_invitation');
+            }
+
+            if (! Schema::hasColumn('notification_preferences', 'routine_reminder')) {
+                $table->boolean('routine_reminder')->default(false)->after('gift_received');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasTable('notification_preferences')) {
+            return;
+        }
+
+        Schema::table('notification_preferences', function (Blueprint $table) {
+            foreach (['routine_reminder', 'gift_received', 'caregiver_invitation', 'appointment_created', 'pet_activity'] as $column) {
+                if (Schema::hasColumn('notification_preferences', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/src/pwa/package-lock.json
+++ b/src/pwa/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "petcare-ui",
+  "name": "petcare-pwa",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "petcare-ui",
+      "name": "petcare-pwa",
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -25,3 +25,13 @@ if (app()->environment('testing')) {
         return response($yaml, 200)->header('Content-Type', 'text/yaml');
     });
 }
+
+if (app()->environment('local') || config('app.debug')) {
+    \Illuminate\Support\Facades\Route::get('/postmark-test', function () {
+        \Illuminate\Support\Facades\Mail::raw('Postmark integration test OK', function ($msg) {
+            $msg->to('contact@slightlyprivate.com')->subject('Postmark Test');
+        });
+
+        return ['status' => 'sent'];
+    });
+}

--- a/src/tests/Feature/NotificationPreferenceTest.php
+++ b/src/tests/Feature/NotificationPreferenceTest.php
@@ -19,12 +19,13 @@ class NotificationPreferenceTest extends TestCase
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $preferences = NotificationPreference::create([
-            'user_id' => $user->id,
-            'otp_notifications' => true,
-            'login_notifications' => false,
-            'gift_notifications' => true,
-            'pet_update_notifications' => false,
+        $preferences = $user->notificationPreferences;
+        $preferences->update([
+            'pet_activity' => true,
+            'gift_received' => true,
+            'appointment_created' => false,
+            'caregiver_invitation' => false,
+            'routine_reminder' => false,
             'sms_enabled' => true,
             'email_enabled' => false,
         ]);
@@ -32,10 +33,11 @@ class NotificationPreferenceTest extends TestCase
         $response = $this->actingAs($user, 'sanctum')->getJson('/api/user/notification-preferences');
 
         $response->assertOk()
-            ->assertJsonPath('data.otp_notifications', true)
-            ->assertJsonPath('data.login_notifications', false)
-            ->assertJsonPath('data.gift_notifications', true)
-            ->assertJsonPath('data.pet_update_notifications', false)
+            ->assertJsonPath('data.pet_activity', true)
+            ->assertJsonPath('data.gift_received', true)
+            ->assertJsonPath('data.appointment_created', false)
+            ->assertJsonPath('data.caregiver_invitation', false)
+            ->assertJsonPath('data.routine_reminder', false)
             ->assertJsonPath('data.sms_enabled', true)
             ->assertJsonPath('data.email_enabled', false);
     }
@@ -51,12 +53,11 @@ class NotificationPreferenceTest extends TestCase
         $response = $this->actingAs($user, 'sanctum')->getJson('/api/user/notification-preferences');
 
         $response->assertOk()
-            ->assertJsonPath('data.otp_notifications', true)
-            ->assertJsonPath('data.login_notifications', true)
-            ->assertJsonPath('data.gift_notifications', true)
-            ->assertJsonPath('data.pet_update_notifications', true)
-            ->assertJsonPath('data.pet_create_notifications', true)
-            ->assertJsonPath('data.pet_delete_notifications', true)
+            ->assertJsonPath('data.pet_activity', false)
+            ->assertJsonPath('data.gift_received', false)
+            ->assertJsonPath('data.appointment_created', false)
+            ->assertJsonPath('data.caregiver_invitation', false)
+            ->assertJsonPath('data.routine_reminder', false)
             ->assertJsonPath('data.sms_enabled', false)
             ->assertJsonPath('data.email_enabled', true);
 
@@ -72,23 +73,18 @@ class NotificationPreferenceTest extends TestCase
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        NotificationPreference::create([
-            'user_id' => $user->id,
-            'otp_notifications' => true,
-        ]);
-
         $response = $this->actingAs($user, 'sanctum')->putJson('/api/user/notification-preferences', [
-            'type' => 'otp',
+            'type' => 'pet_activity',
             'enabled' => false,
         ]);
 
         $response->assertOk()
-            ->assertJsonPath('data.type', 'otp')
+            ->assertJsonPath('data.type', 'pet_activity')
             ->assertJsonPath('data.enabled', false);
 
         $this->assertDatabaseHas('notification_preferences', [
             'user_id' => $user->id,
-            'otp_notifications' => false,
+            'pet_activity' => false,
         ]);
     }
 
@@ -99,14 +95,13 @@ class NotificationPreferenceTest extends TestCase
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $preferences = NotificationPreference::create([
-            'user_id' => $user->id,
-            'otp_notifications' => true,
-            'login_notifications' => true,
-            'gift_notifications' => true,
-            'pet_update_notifications' => true,
-            'pet_create_notifications' => true,
-            'pet_delete_notifications' => true,
+        $preferences = $user->notificationPreferences;
+        $preferences->update([
+            'pet_activity' => true,
+            'appointment_created' => true,
+            'caregiver_invitation' => true,
+            'gift_received' => true,
+            'routine_reminder' => true,
         ]);
 
         $response = $this->actingAs($user, 'sanctum')->postJson('/api/user/notification-preferences/disable-all');
@@ -115,12 +110,11 @@ class NotificationPreferenceTest extends TestCase
             ->assertJsonPath('message', 'All notifications have been disabled.');
 
         $preferences->refresh();
-        $this->assertFalse($preferences->otp_notifications);
-        $this->assertFalse($preferences->login_notifications);
-        $this->assertFalse($preferences->gift_notifications);
-        $this->assertFalse($preferences->pet_update_notifications);
-        $this->assertFalse($preferences->pet_create_notifications);
-        $this->assertFalse($preferences->pet_delete_notifications);
+        $this->assertFalse($preferences->pet_activity);
+        $this->assertFalse($preferences->appointment_created);
+        $this->assertFalse($preferences->caregiver_invitation);
+        $this->assertFalse($preferences->gift_received);
+        $this->assertFalse($preferences->routine_reminder);
     }
 
     /**
@@ -130,14 +124,13 @@ class NotificationPreferenceTest extends TestCase
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $preferences = NotificationPreference::create([
-            'user_id' => $user->id,
-            'otp_notifications' => false,
-            'login_notifications' => false,
-            'gift_notifications' => false,
-            'pet_update_notifications' => false,
-            'pet_create_notifications' => false,
-            'pet_delete_notifications' => false,
+        $preferences = $user->notificationPreferences;
+        $preferences->update([
+            'pet_activity' => false,
+            'appointment_created' => false,
+            'caregiver_invitation' => false,
+            'gift_received' => false,
+            'routine_reminder' => false,
         ]);
 
         $response = $this->actingAs($user, 'sanctum')->postJson('/api/user/notification-preferences/enable-all');
@@ -146,12 +139,11 @@ class NotificationPreferenceTest extends TestCase
             ->assertJsonPath('message', 'All notifications have been enabled.');
 
         $preferences->refresh();
-        $this->assertTrue($preferences->otp_notifications);
-        $this->assertTrue($preferences->login_notifications);
-        $this->assertTrue($preferences->gift_notifications);
-        $this->assertTrue($preferences->pet_update_notifications);
-        $this->assertTrue($preferences->pet_create_notifications);
-        $this->assertTrue($preferences->pet_delete_notifications);
+        $this->assertTrue($preferences->pet_activity);
+        $this->assertTrue($preferences->appointment_created);
+        $this->assertTrue($preferences->caregiver_invitation);
+        $this->assertTrue($preferences->gift_received);
+        $this->assertTrue($preferences->routine_reminder);
     }
 
     /**
@@ -187,16 +179,17 @@ class NotificationPreferenceTest extends TestCase
     public function test_preference_checking_methods(): void
     {
         $user = User::factory()->create();
-        $preferences = NotificationPreference::create([
-            'user_id' => $user->id,
-            'otp_notifications' => true,
-            'login_notifications' => false,
+        $preferences = $user->notificationPreferences;
+        $preferences->update([
+            'pet_activity' => true,
+            'gift_received' => false,
             'sms_enabled' => true,
             'email_enabled' => false,
         ]);
 
+        $this->assertTrue($preferences->isNotificationEnabled('pet_activity'));
+        $this->assertFalse($preferences->isNotificationEnabled('gift_received'));
         $this->assertTrue($preferences->isNotificationEnabled('otp'));
-        $this->assertFalse($preferences->isNotificationEnabled('login'));
         $this->assertTrue($preferences->isChannelEnabled('sms'));
         $this->assertFalse($preferences->isChannelEnabled('email'));
     }
@@ -207,11 +200,6 @@ class NotificationPreferenceTest extends TestCase
     public function test_unique_constraint_on_user_notification_preferences(): void
     {
         $user = User::factory()->create();
-        NotificationPreference::create([
-            'user_id' => $user->id,
-        ]);
-
-        // Attempting to create another preference for the same user should fail
         $this->expectException(\Illuminate\Database\QueryException::class);
         NotificationPreference::create([
             'user_id' => $user->id,
@@ -225,13 +213,8 @@ class NotificationPreferenceTest extends TestCase
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        NotificationPreference::create([
-            'user_id' => $user->id,
-            'gift_notifications' => true,
-        ]);
-
         $response = $this->actingAs($user, 'sanctum')->putJson('/api/user/notification-preferences', [
-            'type' => 'gift',
+            'type' => 'gift_received',
             'enabled' => false,
         ]);
 
@@ -239,24 +222,19 @@ class NotificationPreferenceTest extends TestCase
 
         $this->assertDatabaseHas('notification_preferences', [
             'user_id' => $user->id,
-            'gift_notifications' => false,
+            'gift_received' => false,
         ]);
     }
 
     /**
-     * Test updating pet_create notification preference.
+     * Test updating pet activity notification preference.
      */
-    public function test_user_can_update_pet_create_preference(): void
+    public function test_user_can_update_pet_activity_preference(): void
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        NotificationPreference::create([
-            'user_id' => $user->id,
-            'pet_create_notifications' => true,
-        ]);
-
         $response = $this->actingAs($user, 'sanctum')->putJson('/api/user/notification-preferences', [
-            'type' => 'pet_create',
+            'type' => 'pet_activity',
             'enabled' => false,
         ]);
 
@@ -264,24 +242,19 @@ class NotificationPreferenceTest extends TestCase
 
         $this->assertDatabaseHas('notification_preferences', [
             'user_id' => $user->id,
-            'pet_create_notifications' => false,
+            'pet_activity' => false,
         ]);
     }
 
     /**
-     * Test updating pet_delete notification preference.
+     * Test updating caregiver invitation notification preference.
      */
-    public function test_user_can_update_pet_delete_preference(): void
+    public function test_user_can_update_caregiver_invitation_preference(): void
     {
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        NotificationPreference::create([
-            'user_id' => $user->id,
-            'pet_delete_notifications' => true,
-        ]);
-
         $response = $this->actingAs($user, 'sanctum')->putJson('/api/user/notification-preferences', [
-            'type' => 'pet_delete',
+            'type' => 'caregiver_invitation',
             'enabled' => false,
         ]);
 
@@ -289,7 +262,7 @@ class NotificationPreferenceTest extends TestCase
 
         $this->assertDatabaseHas('notification_preferences', [
             'user_id' => $user->id,
-            'pet_delete_notifications' => false,
+            'caregiver_invitation' => false,
         ]);
     }
 }

--- a/src/tests/Feature/NotificationTest.php
+++ b/src/tests/Feature/NotificationTest.php
@@ -200,13 +200,12 @@ class NotificationTest extends TestCase
 
         /** @var User $user */
         $user = User::factory()->create();
-        $user->notificationPreference()->create([
-            'otp_notifications' => true,
-            'login_notifications' => true,
-            'gift_notifications' => false,
-            'pet_update_notifications' => false,
-            'pet_create_notifications' => false,
-            'pet_delete_notifications' => false,
+        $user->notificationPreferences()->update([
+            'pet_activity' => false,
+            'appointment_created' => false,
+            'caregiver_invitation' => false,
+            'gift_received' => false,
+            'routine_reminder' => false,
             'sms_enabled' => false,
             'email_enabled' => true,
         ]);
@@ -242,12 +241,11 @@ class NotificationTest extends TestCase
         NotificationPreference::updateOrCreate(
             ['user_id' => $user->id],
             [
-                'otp_notifications' => true,
-                'login_notifications' => true,
-                'gift_notifications' => true,
-                'pet_update_notifications' => true,
-                'pet_create_notifications' => true,
-                'pet_delete_notifications' => true,
+                'pet_activity' => true,
+                'appointment_created' => true,
+                'caregiver_invitation' => true,
+                'gift_received' => true,
+                'routine_reminder' => true,
                 'sms_enabled' => false,
                 'email_enabled' => true,
             ]
@@ -411,14 +409,13 @@ class NotificationTest extends TestCase
             'status' => 'pending',
         ]);
 
-        // Create notification preference with gift notifications disabled
-        \App\Models\NotificationPreference::create([
-            'user_id' => $user->id,
-            'gift_notifications' => false,
+        // Disable gift notifications
+        $user->notificationPreferences()->update([
+            'gift_received' => false,
         ]);
 
         // Verify notification is not sent due to disabled preference
-        $isEnabled = \App\Helpers\NotificationHelper::isNotificationEnabled($user, 'gift');
+        $isEnabled = \App\Helpers\NotificationHelper::isNotificationEnabled($user, 'gift_received');
         $this->assertFalse($isEnabled);
 
         // No notification should be sent
@@ -442,10 +439,9 @@ class NotificationTest extends TestCase
             'completed_at' => now(),
         ]);
 
-        // Create notification preference enabled
-        \App\Models\NotificationPreference::create([
-            'user_id' => $user->id,
-            'gift_notifications' => true,
+        // Ensure gift notifications remain enabled
+        $user->notificationPreferences()->update([
+            'gift_received' => true,
         ]);
 
         // Attempt to mark as paid again (status already paid)
@@ -532,10 +528,9 @@ class NotificationTest extends TestCase
             'completed_at' => now(),
         ]);
 
-        // Create notification preference enabled
-        \App\Models\NotificationPreference::create([
-            'user_id' => $user->id,
-            'gift_notifications' => true,
+        // Ensure gift notifications remain enabled
+        $user->notificationPreferences()->update([
+            'gift_received' => true,
         ]);
 
         // Verify no success notification would be sent for failed gifts

--- a/src/tests/Feature/PetApiTest.php
+++ b/src/tests/Feature/PetApiTest.php
@@ -345,6 +345,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['pet_activity' => true]);
         $petData = [
             'name' => 'Buddy',
             'species' => 'Dog',
@@ -367,7 +368,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $user->notificationPreference()->create(['pet_create_notifications' => false]);
+        $user->notificationPreferences()->update(['pet_activity' => false]);
 
         $petData = [
             'name' => 'Buddy',
@@ -392,6 +393,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['pet_activity' => true]);
         $pet = Pet::factory()->for($user)->create();
 
         $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/pets/{$pet->id}");
@@ -408,7 +410,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $user->notificationPreference()->create(['pet_delete_notifications' => false]);
+        $user->notificationPreferences()->update(['pet_activity' => false]);
         $pet = Pet::factory()->for($user)->create();
 
         $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/pets/{$pet->id}");
@@ -426,6 +428,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['pet_activity' => true]);
         $pet = Pet::factory()->for($user)->create([
             'name' => 'Original',
             'species' => 'Dog',
@@ -480,7 +483,7 @@ class PetApiTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
-        $user->notificationPreference()->create(['pet_update_notifications' => false]);
+        $user->notificationPreferences()->update(['pet_activity' => false]);
         $pet = Pet::factory()->for($user)->create([
             'name' => 'Original',
             'species' => 'Dog',

--- a/src/tests/Feature/PetCaregiverInvitationTest.php
+++ b/src/tests/Feature/PetCaregiverInvitationTest.php
@@ -67,6 +67,28 @@ class PetCaregiverInvitationTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_email_caregivers_who_opt_out(): void
+    {
+        Mail::fake();
+
+        /** @var Authenticatable $owner */
+        $owner = User::factory()->create(['email' => 'owner@test.localhost']);
+        /** @var Authenticatable $caregiver */
+        $caregiver = User::factory()->create(['email' => 'caregiver@test.localhost']);
+        $caregiver->notificationPreferences()->update(['caregiver_invitation' => false]);
+
+        $pet = Pet::factory()->for($owner)->create();
+
+        $response = $this->actingAs($owner, 'sanctum')->postJson("/api/pets/{$pet->id}/caregiver-invitations", [
+            'invitee_email' => $caregiver->email,
+        ]);
+
+        $response->assertStatus(201);
+
+        Mail::assertNotQueued(PetCaregiverInvitationMail::class);
+    }
+
+    #[Test]
     public function non_owner_cannot_send_caregiver_invitation()
     {
         /** @var Authenticatable $owner */

--- a/src/tests/Feature/StripeWebhookTest.php
+++ b/src/tests/Feature/StripeWebhookTest.php
@@ -87,6 +87,7 @@ class StripeWebhookTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
         $gift = Gift::factory()->create([
@@ -135,11 +136,11 @@ class StripeWebhookTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
-        NotificationPreference::create([
-            'user_id' => $user->id,
-            'gift_notifications' => false,
+        $user->notificationPreferences()->update([
+            'gift_received' => false,
         ]);
 
         $gift = Gift::factory()->create([
@@ -184,6 +185,7 @@ class StripeWebhookTest extends TestCase
     public function test_webhook_checkout_expired_marks_gift_failed(): void
     {
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
         $gift = Gift::factory()->create([
@@ -289,6 +291,7 @@ class StripeWebhookTest extends TestCase
         Notification::fake();
 
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
         $gift = Gift::factory()->create([
@@ -340,6 +343,7 @@ class StripeWebhookTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
         $gift = Gift::factory()->create([
@@ -390,6 +394,7 @@ class StripeWebhookTest extends TestCase
 
         /** @var Authenticatable $user */
         $user = User::factory()->create();
+        $user->notificationPreferences()->update(['gift_received' => true]);
         $pet = Pet::factory()->create();
 
         $gift = Gift::factory()->create([

--- a/src/tests/Feature/StripeWebhookTest.php
+++ b/src/tests/Feature/StripeWebhookTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\Gift;
-use App\Models\NotificationPreference;
 use App\Models\Pet;
 use App\Models\User;
 use App\Notifications\Gift\GiftSuccessNotification;

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "petcare-pwa",
+  "name": "petcare-ui",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "petcare-pwa",
+      "name": "petcare-ui",
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",


### PR DESCRIPTION
This pull request refactors and expands the notification preferences system, introducing new notification types and improving how user preferences are managed and checked throughout the codebase. The changes ensure that notification logic is more consistent, extensible, and easier to maintain, while also updating related service logic and documentation.

**Notification Preference Model & Logic Updates**
- Added new notification types (`pet_activity`, `appointment_created`, `caregiver_invitation`, `gift_received`, `routine_reminder`) to the `NotificationPreference` model, including updates to fillable fields, casts, activity logging, and bulk enable/disable methods. Also introduced the `mapNotificationColumn` helper for flexible type-to-column mapping. [[1]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756R30-R34) [[2]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756R51-R55) [[3]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756R73-R77) [[4]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756L81-R104) [[5]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756R129-R133) [[6]](diffhunk://#diff-53ab382537ed1051ee0628e047e281982bda8c5cbe44df8d9d734f2170e45756R149-R173)
- Updated the notification type normalization and preference checks in `NotificationHelper` to use the new types and mapping logic, ensuring correct preference lookups and default handling. [[1]](diffhunk://#diff-a87be1512d4949c49403c1d9355f07c26a0dfc126b97d048858f0fecd3bed36cL26-R26) [[2]](diffhunk://#diff-a87be1512d4949c49403c1d9355f07c26a0dfc126b97d048858f0fecd3bed36cL49-R49) [[3]](diffhunk://#diff-a87be1512d4949c49403c1d9355f07c26a0dfc126b97d048858f0fecd3bed36cL66-R72)

**User Model & Preference Initialization**
- Refactored the `User` model to use `notificationPreferences` (plural) instead of `notificationPreference` (singular), including relationship updates and backwards compatibility. Automatically creates default preferences for new users using the latest notification types and channels. [[1]](diffhunk://#diff-43c0010209fd8970b19fa2a6fb9826c2d04a39d94e66bb2f5b540c9d69e61bd0R26-R49) [[2]](diffhunk://#diff-43c0010209fd8970b19fa2a6fb9826c2d04a39d94e66bb2f5b540c9d69e61bd0R115-R119)

**Service & Job Layer Consistency**
- Updated service logic in `NotificationPreferencesService` and related jobs to use the new notification types and pluralized relationship, ensuring preference creation and updates are consistent with the new model. [[1]](diffhunk://#diff-b2781c0588094980d9e33dcca409ecf96fae19f6712b9f8b18b844cc3c848a2dL27-R44) [[2]](diffhunk://#diff-b2781c0588094980d9e33dcca409ecf96fae19f6712b9f8b18b844cc3c848a2dL63-R83) [[3]](diffhunk://#diff-fed14279d89bac9c9fc3fe19d42afa932a323412261ddf889810e191d6aa98e9L70-R70)
- Modified notification checks in feature services (pet creation/update/delete, gift creation, Stripe webhook, caregiver invitation) to use the new notification types, aligning business logic with the updated system. [[1]](diffhunk://#diff-cee6cdd22bf2c1e4f6e75a429e9b3d74cfff8daf1da230653e192148c98feda6L35-R35) [[2]](diffhunk://#diff-cee6cdd22bf2c1e4f6e75a429e9b3d74cfff8daf1da230653e192148c98feda6L54-R54) [[3]](diffhunk://#diff-cee6cdd22bf2c1e4f6e75a429e9b3d74cfff8daf1da230653e192148c98feda6L67-R67) [[4]](diffhunk://#diff-4461551a9fd379445a49191e2f916d9b5943a2167730a8bb61ceff8dbbda33d7L76-R76) [[5]](diffhunk://#diff-728ae57ac5d73bcdd75b371db85f9b47e4aab41129f4a68cbb0834289f1a2940L170-R170) [[6]](diffhunk://#diff-3b4ecaa086b1c9a6b89a9cbe1e4a69d7cbe881c4e1e03aadf678e9c744d659a0R32-R39) [[7]](diffhunk://#diff-3b4ecaa086b1c9a6b89a9cbe1e4a69d7cbe881c4e1e03aadf678e9c744d659a0R48)

**Validation & Documentation**
- Updated request validation rules and documentation to reflect the new notification types, improving API clarity for consumers. [[1]](diffhunk://#diff-6570d8f0891530c8c384293e95f85de934498be456f087226c13d2534ef18183L31-R31) [[2]](diffhunk://#diff-6570d8f0891530c8c384293e95f85de934498be456f087226c13d2534ef18183L47-R47)
- Added documentation and environment variable for Postmark mail transport, clarifying mail configuration and usage of the new notification system. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5L65-R71) [[2]](diffhunk://#diff-37d244a68001b3a8ce7d98f05894470bb8e6fb387402adc29351d41570e3e1e6R58)